### PR TITLE
changed default location of nwcloud.properties

### DIFF
--- a/src/main/scripts/usage.build.xml
+++ b/src/main/scripts/usage.build.xml
@@ -23,7 +23,7 @@
     <!-- ============================================================ -->
 
 	<!-- Read properties from properties file -->
-	<property file="nwcloud.properties"/>
+	<property file="${user.home}/.nwcloud/nwcloud.properties"/>
 
 	<target name="init">
 


### PR DESCRIPTION
request to move  nwcloud.properties from ./ (current directory) to ${user.home}/.nwcloud

with nwcloud.properties in the project directory, no way to use the maven-release-plugin it not by submitting the nwcloud.properties (incl. password) to the scm.

(it must be precised that I have hooked the nwcloud:deploy goal to the maven:deploy lifecycle, as shown around line 50 of https://github.com/cthiebaud/abendrot/blob/1f668c0ea76e7c94a846d8abe3f8f6952945ed37/pom.xml)

also, as mentionned in my blog : http://cthiebaud.github.com/abendrot/, it is unsafe to have a file containing potentially sensitive password in a source directory. ~/.nwcloud location seems more appropriate.

thanks
Christophe
